### PR TITLE
Обновление CI: Замена установки PlantUML на загрузку JAR-файла.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install PlantUML
+      - name: Download PlantUML jar
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y plantuml
+          # fetch the latest PlantUML standalone jar so we don't need sudo
+          curl -sSL -o plantuml.jar \
+            https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar
       - name: Install runtime dependencies
         run: pip install -r requirements.txt
       - name: Install docs dependencies
@@ -138,6 +139,7 @@ jobs:
       - name: Build HTML docs
         env:
           PYTHONPATH: ${{ github.workspace }}
+          PLANTUML_JAR: ${{ github.workspace }}/plantuml.jar
         run: |
           sphinx-build \
             -b html \

--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -87,11 +87,11 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      # Install PlantUML (needed by sphinxcontrib-plantuml)
-      - name: Install PlantUML
+      # Download PlantUML jar (no sudo required)
+      - name: Download PlantUML jar
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y plantuml
+          curl -sSL -o plantuml.jar \
+            https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar
 
       # Install runtime deps so autodoc can import the modules
       - name: Install runtime dependencies
@@ -105,6 +105,7 @@ jobs:
       - name: Build HTML docs
         env:
           PYTHONPATH: .
+          PLANTUML_JAR: ${{ github.workspace }}/plantuml.jar
         run: |
           sphinx-build \
             -b html \


### PR DESCRIPTION
В этом запросе на слияние обновлены рабочие процессы сборки документации: теперь вместо установки PlantUML в масштабе всей системы с помощью `apt-get`, файл `PlantUML` загружается напрямую. Это позволяет избежать необходимости использования `sudo` и гарантирует использование последней версии PlantUML. Рабочие процессы также обновлены для установки переменной среды `PLANTUML_JAR` для сборок Sphinx.

**Улучшения в CI и рабочих процессах создания документации:**

* Заменена установка PlantUML в масштабе всей системы через `apt-get` на прямую загрузку последней версии `plantuml.jar` с помощью `curl` в файлах `.github/workflows/ci.yml` и `.github/workflows/docs-gh-pages.yml`, что исключает необходимость использования `sudo` и гарантирует актуальность PlantUML. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL130-R142) [[2]](diffhunk://#diff-6a3c363d8b88582d2e328244203f5b7ae1a0b1b5df2881fbd120185a0a60402fL90-R94)
* Обновлены шаги сборки документации Sphinx в обоих рабочих процессах для установки переменной среды `PLANTUML_JAR`, что позволяет Sphinx использовать загруженный jar-файл для генерации диаграмм. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL130-R142) [[2]](diffhunk://#diff-6a3c363d8b88582d2e328244203f5b7ae1a0b1b5df2881fbd120185a0a60402fR108)